### PR TITLE
fix: add support for text based image files (e.g. .svg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2024-05-10
+
+- Added support for text based image files like SVG etc.
+- Added support for redirecting to the actual image URL.
+
 # 2023-03-13
 
 - Add two new option `items` and `outputDatasetId` to input.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "image-size": "^0.6.3",
         "jimp": "^0.21.0",
         "md5": "^2.2.1",
+        "mime": "^4.0.4",
         "needle": "^3.2.0",
         "object-path": "^0.11.8",
         "request-fixed-tunnel-agent": "^2.88.3",
@@ -3638,6 +3639,18 @@
         "xtend": "^4.0.0"
       }
     },
+    "node_modules/load-bmfont/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -3745,14 +3758,18 @@
       }
     },
     "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.4.tgz",
+      "integrity": "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa"
+      ],
+      "license": "MIT",
       "bin": {
-        "mime": "cli.js"
+        "mime": "bin/cli.js"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=16"
       }
     },
     "node_modules/mime-db": {

--- a/package.json
+++ b/package.json
@@ -28,19 +28,20 @@
     "image-size": "^0.6.3",
     "jimp": "^0.21.0",
     "md5": "^2.2.1",
+    "mime": "^4.0.4",
     "needle": "^3.2.0",
     "object-path": "^0.11.8",
     "request-fixed-tunnel-agent": "^2.88.3",
     "webp-converter": "kilohaty/webp-converter"
   },
   "devDependencies": {
-    "@types/image-size": "0.0.29",
-    "@types/jimp": "^0.2.28",
-    "@types/object-path": "^0.11.1",
     "@apify/tsconfig": "^0.1.0",
     "@types/archiver": "^5.3.1",
     "@types/crypto-js": "^4.1.1",
+    "@types/image-size": "0.0.29",
+    "@types/jimp": "^0.2.28",
     "@types/needle": "^3.2.0",
+    "@types/object-path": "^0.11.1",
     "ts-node": "^10.9.1",
     "typescript": "^4.7.4"
   }

--- a/src/download-upload.ts
+++ b/src/download-upload.ts
@@ -74,6 +74,7 @@ const download = async (url: string, imageCheck: ImageCheck, key: string, downlo
             needle("get", url, {
                 agent: proxyAgent,
                 setEncoding: null,
+                follow_max: 5,
             }).catch(err => {
                 throw new Error(err);
             }),
@@ -91,7 +92,11 @@ const download = async (url: string, imageCheck: ImageCheck, key: string, downlo
         if (!response) continue;
 
         const startProcessing = Date.now();
-        const { isImage, error, retry, contentType, sizes } = await checkIfImage(response, imageCheck);
+
+        const isRedirect = [301, 302].includes(response.statusCode);
+        const imageUrl = isRedirect ? response.headers.location : url;
+
+        const { isImage, error, retry, contentType, sizes } = await checkIfImage(response, imageCheck, imageUrl);
         sizesMain = sizes;
         timeProcessing += Date.now() - startProcessing;
 


### PR DESCRIPTION
Fixes #18 

---
- Adds support for text based image files (.e.g .svg)
  - this is done by checking the URL path of the files
- Also adds support for redirects

I need this for the bundle :D

@metalwarrior665 