### PR TITLE
fix: image archiving for text based files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2024-05-10
+# 2024-10-10
+
+- Fixed ZIP file upload issue for new text based image files (e.g. SVG).
+
+# 2024-10-05
 
 - Added support for text based image files like SVG etc.
 - Added support for redirecting to the actual image URL.

--- a/src/archive-files.ts
+++ b/src/archive-files.ts
@@ -1,7 +1,7 @@
-import { KeyValueStore, log } from "crawlee";
-import archiver from "archiver";
-import { fileTypeFromBuffer, FileTypeResult } from "file-type";
-import fs from "fs";
+import archiver from 'archiver';
+import { KeyValueStore, log } from 'crawlee';
+import fs from 'fs';
+import mime from 'mime';
 
 const archiveFilePath = `./archive.zip`;
 
@@ -23,10 +23,10 @@ export const archiveKVS = async (store: KeyValueStore) => {
     archive.pipe(output);
 
     await store.forEachKey(async (key) => {
-        const buffer = (await store.getValue(key)) as Buffer;
-        const { ext } = await fileTypeFromBuffer(buffer) as FileTypeResult;
+        const { buffer, contentType } = (await store.getValue(key)) as { buffer: Buffer | string; contentType: string };
+        const extension = mime.getExtension(contentType);
 
-        archive.append(buffer, { name: `${key}.${ext}` });
+        archive.append(Buffer.from(buffer), { name: `${key}.${extension}` });
     });
 
     await archive.finalize();


### PR DESCRIPTION
Fixes https://github.com/metalwarrior665/actor-images-download-upload/issues/20

---
### Text files were failing to get assigned a file extension during the zip files upload.

- It was a bit more annoying to implement, because unlike regular buffer files, they rely more on their URL path rather than their actual content. The URL path was not passed down the temporary download KVS, so I had to kinda hack it into it by saving it as JSON with the buffer and the content type.

cc. @metalwarrior665 